### PR TITLE
Adds templating for namespace

### DIFF
--- a/helm/cert-exporter-chart/templates/daemonset.yaml
+++ b/helm/cert-exporter-chart/templates/daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: cert-exporter
-  namespace: monitoring
+  namespace: {{ .Values.namespace }}
   labels:
     app: cert-exporter
 spec:

--- a/helm/cert-exporter-chart/templates/pull-secret.yaml
+++ b/helm/cert-exporter-chart/templates/pull-secret.yaml
@@ -3,6 +3,6 @@ kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
   name: cert-exporter-pull-secret
-  namespace: monitoring
+  namespace: {{ .Values.namespace }}
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/cert-exporter-chart/templates/rbac.yaml
+++ b/helm/cert-exporter-chart/templates/rbac.yaml
@@ -19,7 +19,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: cert-exporter
-    namespace: monitoring
+    namespace: {{ .Values.namespace }}
 roleRef:
   kind: ClusterRole
   name: cert-exporter-psp

--- a/helm/cert-exporter-chart/templates/service-account.yaml
+++ b/helm/cert-exporter-chart/templates/service-account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cert-exporter
-  namespace: monitoring
+  namespace: {{ .Values.namespace }}

--- a/helm/cert-exporter-chart/templates/service.yaml
+++ b/helm/cert-exporter-chart/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cert-exporter
-  namespace: monitoring
+  namespace: {{ .Values.namespace }}
   labels:
     app: cert-exporter
   annotations:

--- a/helm/cert-exporter-chart/values.yaml
+++ b/helm/cert-exporter-chart/values.yaml
@@ -1,0 +1,1 @@
+namespace: monitoring


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3913

Same as with https://github.com/giantswarm/net-exporter/pull/7, we currently deploy `cert-exporter` to the `monitoring` namespace in control planes, but want it in `kube-system` in tenant clusters. This PR adds templating for the namespace, and sets the default to `monitoring`.