### PR TITLE
Adds support for running in tenant clusters

### DIFF
--- a/helm/cert-exporter-chart/templates/daemonset.yaml
+++ b/helm/cert-exporter-chart/templates/daemonset.yaml
@@ -26,9 +26,17 @@ spec:
       - name: cert-exporter
         image: quay.io/giantswarm/cert-exporter:[[ .SHA ]]
         args:
+        {{ if (.Values.Installation) }}
         - --path={{ .Values.Installation.V1.Monitoring.CertExporter.CertPath }}
+        {{ else }}
+        - --path=/etc/kubernetes/ssl
+        {{ end }}
+        {{ if (.Values.Installation) }}
         - --token-path={{ .Values.Installation.V1.Monitoring.CertExporter.TokenPath }}
+        {{ end }}
+        {{ if (.Values.Installation) }}
         - --vault-url={{ .Values.Installation.V1.Auth.Vault.Address }}
+        {{ end }}
         ports:
         - name: cert-exporter
           containerPort: 9005
@@ -40,23 +48,34 @@ spec:
             cpu: 50m
             memory: 50Mi
         volumeMounts:
+        {{ if (.Values.Installation) }}
         - mountPath: {{ .Values.Installation.V1.Monitoring.CertExporter.CertPath }}
           name: certs-volume
+        {{ else }}
+        - mountPath: /etc/kubernetes/ssl
+          name: certs-volume
+        {{ end }}
+        {{ if (.Values.Installation) }}
         - mountPath: {{ .Values.Installation.V1.Monitoring.CertExporter.TokenPath }}
           name: tokens-volume
+        {{ end }}
         - mountPath: /etc/ssl/certs/
           name: ca-certs
       volumes:
       - name: certs-volume
         hostPath:
+          {{ if (.Values.Installation) }}
           path: {{ .Values.Installation.V1.Monitoring.CertExporter.CertPath }}
+          {{ else }}
+          path: /etc/kubernetes/ssl
+          {{ end }}
+      {{ if (.Values.Installation) }}
       - name: tokens-volume
         hostPath:
           path: {{ .Values.Installation.V1.Monitoring.CertExporter.TokenPath }}
+      {{ end }}
       - name: ca-certs
         hostPath:
           path: /etc/ssl/certs/
       hostNetwork: true
       hostPID: true
-      imagePullSecrets:
-      - name: cert-exporter-pull-secret

--- a/helm/cert-exporter-chart/templates/pull-secret.yaml
+++ b/helm/cert-exporter-chart/templates/pull-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/dockerconfigjson
-metadata:
-  name: cert-exporter-pull-secret
-  namespace: {{ .Values.namespace }}
-data:
-  .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/main.go
+++ b/main.go
@@ -63,14 +63,7 @@ func main() {
 	}
 
 	// Expose Vault token metrics.
-	{
-		if tokenPath == "" {
-			panic(microerror.Maskf(invalidConfigError, "path to token folder can not be empty"))
-		}
-		if vaultURL == "" {
-			panic(microerror.Maskf(invalidConfigError, "Vault URL can not be empty"))
-		}
-
+	if tokenPath != "" && vaultURL != "" {
 		c := token.Config{
 			Path:     tokenPath,
 			VaultURL: vaultURL,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3913

control plane:
```
Every 2.0s: kubectl -n=monitoring get pod -l=app=cert-exporter -o wide                                                            Josephs-MacBook-Pro.local: Fri Aug 17 10:49:12 2018

NAME                  READY     STATUS    RESTARTS   AGE       IP         NODE
cert-exporter-bmmrr   1/1       Running   0          1m        10.0.2.5   worker0
cert-exporter-d4gf9   1/1       Running   0          1m        10.0.2.4   worker2
cert-exporter-gh88x   1/1       Running   0          1m        10.0.2.6   worker1
cert-exporter-scqws   1/1       Running   0          1m        10.0.2.7   master0
```

control plane master:
```
$ curl -Ss 10.0.2.7:9005/metrics | grep cert_exporter
# HELP cert_exporter_not_after Timestamp after which the cert is invalid.
# TYPE cert_exporter_not_after gauge
cert_exporter_not_after{path="/etc/kubernetes/ssl/apiserver-ca.pem"} 1.840099707e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/apiserver-crt.pem"} 1.565866085e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/calico/client-ca.pem"} 1.840099707e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/calico/client-crt.pem"} 1.565866082e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/client-ca.pem"} 1.840099707e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/client-crt.pem"} 1.565866082e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/server-ca.pem"} 1.840099707e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/server-crt.pem"} 1.565866082e+09
# HELP cert_exporter_token_not_after Timestamp after which the Vault token is expired.
# TYPE cert_exporter_token_not_after gauge
cert_exporter_token_not_after{path="/etc/tokens/node"} 1.547390415e+09
```

control plane worker:
```
$ curl -Ss 10.0.2.5:9005/metrics | grep cert_exporter
# HELP cert_exporter_not_after Timestamp after which the cert is invalid.
# TYPE cert_exporter_not_after gauge
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/client-ca.pem"} 1.840099707e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/client-crt.pem"} 1.565867141e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/worker-ca.pem"} 1.840099707e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/worker-crt.pem"} 1.565867141e+09
# HELP cert_exporter_token_not_after Timestamp after which the Vault token is expired.
# TYPE cert_exporter_token_not_after gauge
cert_exporter_token_not_after{path="/etc/tokens/node"} 1.547390415e+09
```

tenant cluster:
```
Every 2.0s: kubectl -n=kube-system get pod -l=app=cert-exporter -o wide                                                           Josephs-MacBook-Pro.local: Fri Aug 17 10:51:38 2018

NAME                  READY     STATUS    RESTARTS   AGE       IP         NODE
cert-exporter-b8cl7   1/1       Running   0          1m        10.1.1.7   4bims-worker-000003
cert-exporter-fsbqb   1/1       Running   0          1m        10.1.1.4   4bims-worker-000000
cert-exporter-wd4fh   1/1       Running   0          1m        10.1.0.5   4bims-master-000000
cert-exporter-zjj7v   1/1       Running   0          1m        10.1.1.6   4bims-worker-000002
```

tenant cluster master:
```
$ curl -Ss 10.1.0.5:9005/metrics | grep cert_exporter
# HELP cert_exporter_not_after Timestamp after which the cert is invalid.
# TYPE cert_exporter_not_after gauge
cert_exporter_not_after{path="/etc/kubernetes/ssl/apiserver-ca.pem"} 1.849699464e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/apiserver-crt.pem"} 1.549891465e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/calico/client-ca.pem"} 1.849699464e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/calico/client-crt.pem"} 1.549891465e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/calico-client-ca.pem"} 1.849699464e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/calico-client-crt.pem"} 1.549891466e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/client-ca.pem"} 1.849699464e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/client-crt.pem"} 1.549891467e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/server-ca.pem"} 1.849699464e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/server-crt.pem"} 1.549891467e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/service-account-ca.pem"} 1.849699464e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/service-account-crt.pem"} 1.549891469e+09
```

tenant cluster worker:
```
$ curl -Ss 10.1.1.4:9005/metrics | grep cert_exporter
# HELP cert_exporter_not_after Timestamp after which the cert is invalid.
# TYPE cert_exporter_not_after gauge
cert_exporter_not_after{path="/etc/kubernetes/ssl/calico/client-ca.pem"} 1.849699464e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/calico/client-crt.pem"} 1.549891465e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/calico-client-ca.pem"} 1.849699464e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/calico-client-crt.pem"} 1.549891466e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/client-ca.pem"} 1.849699464e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/etcd/client-crt.pem"} 1.549891467e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/worker-ca.pem"} 1.849699464e+09
cert_exporter_not_after{path="/etc/kubernetes/ssl/worker-crt.pem"} 1.549891469e+09
```

Please note that vault tokens are reported for the control plane, but not the tenant cluster.