### PR TITLE
Use apps/v1 for daemonset

### DIFF
--- a/helm/cert-exporter-chart/templates/daemonset.yaml
+++ b/helm/cert-exporter-chart/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cert-exporter


### PR DESCRIPTION
This came up in sig-upgrades sync. We should use apps/v1 for new daemonsets and deployments.