### PR TITLE
Template docker image

### DIFF
--- a/helm/cert-exporter-chart/templates/daemonset.yaml
+++ b/helm/cert-exporter-chart/templates/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: cert-exporter
       containers:
       - name: cert-exporter
-        image: quay.io/giantswarm/cert-exporter:[[ .SHA ]]
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         args:
         {{ if (.Values.Installation) }}
         - --cert-paths={{ .Values.Installation.V1.Monitoring.CertExporter.CertPath }}

--- a/helm/cert-exporter-chart/values.yaml
+++ b/helm/cert-exporter-chart/values.yaml
@@ -1,1 +1,6 @@
 namespace: monitoring
+
+image:
+  registry: quay.io
+  repository: giantswarm/cert-exporter
+  tag: [[ .SHA ]]


### PR DESCRIPTION
Templates the docker image as we do on chart-operator. As cert-exporter is installed by draughtsman and chart-operator. This is so we can set the tag in e2e tests. 

