### PR TITLE
Publish to stable channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
 
     - run: |
         sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/cert-exporter-chart/Chart.yaml
-        ./architect publish
+        ./architect publish --stable=true
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
 
     - run: |
         sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/cert-exporter-chart/Chart.yaml
-        ./architect publish --stable=true
+        ./architect publish --channels=stable
 
 workflows:
   version: 2


### PR DESCRIPTION
Fixes problem with previous PR.

For cert-exporter the stable channel is used as the release channel by chart-operator. So the release with the SHA suffix should be pushed to the stable channel.

![screen shot 2018-09-17 at 12 18 27 pm](https://user-images.githubusercontent.com/311527/45617854-f210e900-ba73-11e8-9261-12aa82cfd26a.png)

