### PR TITLE
Remove sed and architect publish from deploy command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,10 +69,6 @@ jobs:
 
     - run: ./architect deploy
 
-    - run: |
-        sed -i 's/version:.*/version: 1.0.0-'"${CIRCLE_SHA1}"'/' helm/cert-exporter-chart/Chart.yaml
-        ./architect publish --channels=stable
-
 workflows:
   version: 2
   build_e2e:


### PR DESCRIPTION
cert-exporter deploys aren't working correctly because the stable channel in CNR has version `1.0.0`. The version should include the -SHA suffix.

Removing the sed magic and publish command which was based on chart-operator. AIUI calling `architect deploy` will publish the chart with `1.0.0-SHA` to `stable` which is all that is needed.

 