### PR TITLE
Tell autoscaler that the pod is safe to evict

### DIFF
--- a/helm/cert-exporter-chart/templates/daemonset.yaml
+++ b/helm/cert-exporter-chart/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: cert-exporter
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: true
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         releasetime: {{ $.Release.Time }}
     spec:
       tolerations:

--- a/helm/cert-exporter-chart/templates/daemonset.yaml
+++ b/helm/cert-exporter-chart/templates/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: cert-exporter
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: true
         releasetime: {{ $.Release.Time }}
     spec:
       tolerations:


### PR DESCRIPTION
This is so that the cluster-autoscaler actually scales down a node when only our workload is remaining.
In small nodes (e.g. m3.large) our own workload might make up more than 50% of the nodes workload and will therefor never be scaled down. This annotation is only for the autoscaler to only consider "real" workload.

More reading: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node

towards giantswarm/giantswarm#4543