### PR TITLE
Revert "Switch to non-root user (#31)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
-FROM quay.io/giantswarm/alpine:3.9-giantswarm
-
-USER root
+FROM alpine:3.8
 
 RUN apk add --update ca-certificates \
     && rm -rf /var/cache/apk/*
 
 ADD ./cert-exporter /cert-exporter
-
-USER giantswarm
 
 ENTRYPOINT ["/cert-exporter"]

--- a/helm/cert-exporter-chart/templates/daemonset.yaml
+++ b/helm/cert-exporter-chart/templates/daemonset.yaml
@@ -25,9 +25,6 @@ spec:
         operator: Exists
         effect: NoSchedule
       serviceAccountName: cert-exporter
-      securityContext:
-        runAsUser: {{ .Values.userID }}
-        runAsGroup: {{ .Values.groupID }}
       containers:
       - name: cert-exporter
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/cert-exporter-chart/templates/psp.yaml
+++ b/helm/cert-exporter-chart/templates/psp.yaml
@@ -4,20 +4,14 @@ metadata:
   name: cert-exporter-psp
 spec:
   privileged: false
+  fsGroup:
+    rule: RunAsAny
   runAsUser:
-    rule: MustRunAsNonRoot
+    rule: RunAsAny
   seLinux:
     rule: RunAsAny
   supplementalGroups:
-    rule: 'MustRunAs'
-    ranges:
-      - min: 1
-        max: 65535
-  fsGroup:
-    rule: 'MustRunAs'
-    ranges:
-      - min: 1
-        max: 65535
+    rule: RunAsAny
   hostPorts:
   - max: 9005
     min: 9005

--- a/helm/cert-exporter-chart/values.yaml
+++ b/helm/cert-exporter-chart/values.yaml
@@ -1,8 +1,5 @@
 namespace: monitoring
 
-userID: 1000
-groupID: 1000
-
 image:
   registry: quay.io
   repository: giantswarm/cert-exporter


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6406

We ran into an issue where cert-exporter does not report metrics for expired certificates on tenant cluster.
It fails to do so due to certificates being only readable by root and cert-exporter run as giantswarm user.

This reverts commit ccabb137861010658dea24b269d7cebb1cb6f128.