### PR TITLE
Use giantswarm-critical priority class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Tolerations changed to tolerate all taints.
+- Change prioty class to `giantswarm-critical`.
 
 [Unreleased]: https://github.com/giantswarm/cert-exporter/compare/v1.1.0...HEAD

--- a/helm/cert-exporter-chart/templates/daemonset.yaml
+++ b/helm/cert-exporter-chart/templates/daemonset.yaml
@@ -23,6 +23,7 @@ spec:
       # Tolerate all taints for observability
       - operator: "Exists"
       serviceAccountName: cert-exporter
+      priorityClassName: giantswarm-critical
       containers:
       - name: cert-exporter
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6556
As daemonsets are scheduled with default scheduler starting from 1.12 by default - we can prioritize them as well