### PR TITLE
Explicitly list all direct dependencies

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,7 +42,15 @@ required = [
   branch = "master"
 
 [[constraint]]
+  name = "github.com/giantswarm/apprclient"
+  branch = "master"
+
+[[constraint]]
   name = "github.com/giantswarm/e2esetup"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/giantswarm/e2etests"
   branch = "master"
 
 [[constraint]]


### PR DESCRIPTION
Leftover from https://github.com/giantswarm/cert-exporter/pull/47

Without these `dep ensure --update` would panic, would pass only once run in verbose mode.