### PR TITLE
Fix egress ports to vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add exceptions in NetworkPolicies to allow DNS to work correctly through port 53.
+
 ## [1.5.0] - 2021-01-05
 
 ### Changed

--- a/exporters/token/exporter.go
+++ b/exporters/token/exporter.go
@@ -140,7 +140,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 		_, err = e.client.Sys().Health()
 		if err != nil {
-			e.logger.Log("warning", "vault is not healthy")
+			e.logger.Log("vault is not healthy error:", microerror.Mask(err))
 			continue
 		}
 

--- a/helm/cert-exporter/templates/np.yaml
+++ b/helm/cert-exporter/templates/np.yaml
@@ -29,6 +29,9 @@ spec:
   - ports:
     - port: 53
       protocol: UDP
+    # DNS uses TCP when the response is larger than 512 bytes
+    - port: 53
+      protocol: TCP
     - port: 443
       protocol: TCP
     # legacy port kept for compatibility

--- a/helm/cert-exporter/templates/np.yaml
+++ b/helm/cert-exporter/templates/np.yaml
@@ -27,6 +27,8 @@ spec:
     {{ end }}
   egress:
   - ports:
+    - port: 53
+      protocol: UDP
     - port: 443
       protocol: TCP
     # legacy port kept for compatibility


### PR DESCRIPTION
Fix PM where cert-exporter is unable to reach vault. Tested on `ginger` and seems to work flawlessly now.

Filtered logs:
```
{"caller":"github.com/giantswarm/cert-exporter/exporters/token/exporter.go:84","info":"collecting vault metrics","time":"2021-01-27T09:27:57.63192+00:00"}
{"caller":"github.com/giantswarm/cert-exporter/exporters/token/exporter.go:164","info":"added /etc/tokens/node to the metrics","time":"2021-01-27T09:27:57.671545+00:00"}
{"caller":"github.com/giantswarm/cert-exporter/exporters/token/exporter.go:167","info":"finished collecting vault metrics","time":"2021-01-27T09:27:57.671568+00:00"}
```