### PR TITLE
Add issuer as label to cert_exporter_secret_not_after, remove certType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Remove static certificate source label (static value `secret`) from `cert_exporter_secret_not_after` metric.
+- Add certificate issuer label to `cert_exporter_secret_not_after` metric.
+
 ## [1.6.1] - 2021-03-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Remove static certificate source label (static value `secret`) from `cert_exporter_secret_not_after` metric.
-- Add certificate issuer label to `cert_exporter_secret_not_after` metric.
+- Remove static certificate source label (static value `secret`) from `cert_exporter_secret_not_after` and `cert_exporter_not_after` metrics.
+- Add certificate issuer label to `cert_exporter_secret_not_after` and `cert_exporter_not_after` metrics.
 
 ## [1.6.1] - 2021-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Remove static certificate source label (static value `secret`) from `cert_exporter_secret_not_after` and `cert_exporter_not_after` metrics.
+- Remove static certificate source label from `cert_exporter_secret_not_after` (static value `secret`) and `cert_exporter_not_after` (static value `file`) metrics.
 - Add certificate issuer label to `cert_exporter_secret_not_after` and `cert_exporter_not_after` metrics.
 
 ## [1.6.1] - 2021-03-26

--- a/exporters/cert/exporter.go
+++ b/exporters/cert/exporter.go
@@ -13,10 +13,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-const (
-	certType = "file"
-)
-
 type Config struct {
 	Paths []string
 }
@@ -81,7 +77,8 @@ func (e *Exporter) collectPath(ch chan<- prometheus.Metric, path string) error {
 
 			for _, cert := range certs {
 				timestamp := float64(cert.NotAfter.Unix())
-				ch <- prometheus.MustNewConstMetric(e.cert, prometheus.GaugeValue, timestamp, fpath, certType)
+				issuer := cert.Issuer.String()
+				ch <- prometheus.MustNewConstMetric(e.cert, prometheus.GaugeValue, timestamp, fpath, issuer)
 			}
 			e.logger.Log("info", fmt.Sprintf("added %s to the metrics", fpath))
 
@@ -126,7 +123,7 @@ func New(config Config) (*Exporter, error) {
 			"Timestamp after which the cert is invalid.",
 			[]string{
 				"path",
-				"type",
+				"issuer",
 			},
 			nil,
 		),

--- a/exporters/secret/exporter.go
+++ b/exporters/secret/exporter.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	fieldSelector = "type=kubernetes.io/tls"
-	certType      = "secret"
 )
 
 type Config struct {
@@ -102,7 +101,8 @@ func (e *Exporter) calculateExpiry(ch chan<- prometheus.Metric, secret v1.Secret
 
 		for _, cert := range certs {
 			timestamp := float64(cert.NotAfter.Unix())
-			ch <- prometheus.MustNewConstMetric(e.cert, prometheus.GaugeValue, timestamp, secretName, secretNamespace, certKey, certType)
+			issuer := cert.Issuer.String()
+			ch <- prometheus.MustNewConstMetric(e.cert, prometheus.GaugeValue, timestamp, secretName, secretNamespace, certKey, issuer)
 		}
 	}
 	e.logger.Log("info", fmt.Sprintf("added secret %s/%s to the metrics", secretNamespace, secretName))
@@ -153,7 +153,7 @@ func New(config Config) (*Exporter, error) {
 				"name",
 				"namespace",
 				"secretkey",
-				"type",
+				"issuer",
 			},
 			nil,
 		),


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16879 trying to make oncall a little more quiet through only alerting for giantswarm managed certificates.

Merging this PR will:

- Remove static certificate source label (static value `secret` and `file`) from `cert_exporter_secret_not_after` and `cert_exporter_not_after` metrics. The label is static and kind of implied for the metrics.
- Add certificate issuer label to `cert_exporter_secret_not_after` metric.

(Review from ludacris since intranet says you own this stuff)