### PR TITLE
Include managed Isser in certificate cr metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Export presence of `giantswarm.io/service-type: managed` label in cert-manager `Issuer` and `ClusterIssuer` CR referenced by `Certificate` CR `issuerRef` spec field to `cert_exporter_certificate_cr_not_after` metric as `managed_issuer` label.
+
 ## [1.8.0] - 2021-08-25
 
 ### Added

--- a/exporters/cr/exporter.go
+++ b/exporters/cr/exporter.go
@@ -22,6 +22,25 @@ var certManagerCertificateGroupVersionResource = schema.GroupVersionResource{
 	Version:  "v1",
 }
 
+var certManagerIssuerGroupVersionResource = schema.GroupVersionResource{
+	Group:    "cert-manager.io",
+	Resource: "issuers",
+	Version:  "v1",
+}
+
+var certManagerClusterIssuerGroupVersionResource = schema.GroupVersionResource{
+	Group:    "cert-manager.io",
+	Resource: "clusterissuers",
+	Version:  "v1",
+}
+
+const (
+	issuerLabelSelector = "giantswarm.io/service-type=managed"
+	trueString          = "true"
+	falseString         = "false"
+	unknownString       = ""
+)
+
 type Config struct {
 	Namespaces []string
 }
@@ -77,10 +96,22 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			if err != nil {
 				e.logger.Log("error", microerror.Mask(err))
 			}
+			issuerRefKind, _, err := unstructured.NestedString(cert.UnstructuredContent(), "spec", "issuerRef", "kind")
+			if err != nil {
+				e.logger.Log("error", microerror.Mask(err))
+			}
 
 			certficateName := cert.GetName()
 			certificateNamespace := cert.GetNamespace()
-			ch <- prometheus.MustNewConstMetric(e.certNotAfter, prometheus.GaugeValue, notAfterUnix, certficateName, certificateNamespace, issuerRefName)
+			isManaged := ""
+
+			if issuerRefKind == "ClusterIssuer" {
+				isManaged = e.CheckClusterIssuerManaged(issuerRefName)
+			} else {
+				isManaged = e.CheckIssuerManaged(issuerRefName, certificateNamespace)
+			}
+
+			ch <- prometheus.MustNewConstMetric(e.certNotAfter, prometheus.GaugeValue, notAfterUnix, certficateName, certificateNamespace, issuerRefName, isManaged)
 
 			e.logger.Log("info", fmt.Sprintf("added cert-manager certificate CR %s/%s to the metrics", certificateNamespace, certficateName))
 		}
@@ -92,6 +123,44 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.certNotAfter
+}
+
+func (e *Exporter) CheckIssuerManaged(name, namespace string) string {
+	listOptions := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", name),
+		LabelSelector: issuerLabelSelector,
+	}
+
+	issuersList, err := e.dynamicClient.Resource(certManagerIssuerGroupVersionResource).Namespace(namespace).List(e.ctx, listOptions)
+	if err != nil {
+		e.logger.Log("error", microerror.Mask(err))
+		return unknownString
+	}
+
+	if len(issuersList.Items) == 1 {
+		return trueString
+	}
+
+	return falseString
+}
+
+func (e *Exporter) CheckClusterIssuerManaged(name string) string {
+	listOptions := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", name),
+		LabelSelector: issuerLabelSelector,
+	}
+
+	clusterIssuersList, err := e.dynamicClient.Resource(certManagerClusterIssuerGroupVersionResource).List(e.ctx, listOptions)
+	if err != nil {
+		e.logger.Log("error", microerror.Mask(err))
+		return unknownString
+	}
+
+	if len(clusterIssuersList.Items) == 1 {
+		return trueString
+	}
+
+	return falseString
 }
 
 func New(config Config) (*Exporter, error) {
@@ -131,6 +200,7 @@ func New(config Config) (*Exporter, error) {
 				"name",
 				"namespace",
 				"issuer_ref",
+				"managed_issuer",
 			},
 			nil,
 		),

--- a/exporters/cr/exporter.go
+++ b/exporters/cr/exporter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -75,7 +76,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	for _, namespace := range namespacesToCheck {
 		certs, err := e.dynamicClient.Resource(certManagerCertificateGroupVersionResource).Namespace(namespace).List(e.ctx, listOptions)
 		if err != nil {
-			e.logger.Log("error", microerror.Mask(err))
+			if !errors.IsNotFound(err) {
+				e.logger.Log("error", microerror.Mask(err))
+			}
 			continue
 		}
 		for _, cert := range certs.Items {

--- a/exporters/cr/exporter.go
+++ b/exporters/cr/exporter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -76,7 +76,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	for _, namespace := range namespacesToCheck {
 		certs, err := e.dynamicClient.Resource(certManagerCertificateGroupVersionResource).Namespace(namespace).List(e.ctx, listOptions)
 		if err != nil {
-			if !errors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				e.logger.Log("error", microerror.Mask(err))
 			}
 			continue

--- a/helm/cert-exporter/templates/rbac.yaml
+++ b/helm/cert-exporter/templates/rbac.yaml
@@ -21,6 +21,8 @@ rules:
       - "cert-manager.io"
     resources:
       - "certificates"
+      - "clusterissuers"
+      - "issuers"
     verbs:
       - list
 ---


### PR DESCRIPTION
This PR changes the `cert_exporter_certificate_cr_not_after` metric to include a metric label showing if the referenced Issuer has a certain label