### PR TITLE
Allow egress to port 1053 to make in-cluster DNS queries work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow egress to port 1053 to make in-cluster DNS queries work.
+
 ## [2.1.0] - 2022-02-01
 
 ### Changed

--- a/helm/cert-exporter/templates/np.yaml
+++ b/helm/cert-exporter/templates/np.yaml
@@ -32,6 +32,11 @@ spec:
     # DNS uses TCP when the response is larger than 512 bytes
     - port: 53
       protocol: TCP
+    - port: 1053
+      protocol: UDP
+    # DNS uses TCP when the response is larger than 512 bytes
+    - port: 1053
+      protocol: TCP
     to:
     {{ range $index, $privateSubnet := $privateSubnets }}
     - ipBlock:


### PR DESCRIPTION
While troubleshooting a failing cert-exporter scrape, I found this error in the logs:

```
U 03/16 10:50:11 | cert-exporter/exporters/token/exporter.go:143 | vault is not healthy error:=map[annotation:Get "https://vault.giddy.westeurope.azure.gigantic.io:443/v1/sys/health?drsecondarycode=299&performancestandbycode=299&sealedcode=299&standbycode=299&uninitcode=299": dial tcp: lookup vault.giddy.westeurope.azure.gigantic.io on 172.31.0.10:53: read udp 10.0.130.10:33780->172.31.0.10:53: i/o timeout kind:unknown stack:[map[file:/root/project/exporters/token/exporter.go line:143]]]
```

the coredns pods run on port 1053, so that port need to be allowed as well otherwise DNS resolving does not work.