### PR TITLE
Allow egress to port 443 to make vault scraping to work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Fixed
 
 - Allow egress to port 1053 to make in-cluster DNS queries work.
+- Allow egress to port 443 to allow accessing vault.
 
 ## [2.1.0] - 2022-02-01
 

--- a/helm/cert-exporter/templates/np.yaml
+++ b/helm/cert-exporter/templates/np.yaml
@@ -37,6 +37,9 @@ spec:
     # DNS uses TCP when the response is larger than 512 bytes
     - port: 1053
       protocol: TCP
+    # To scrape the vault token expiration
+    - port: 443
+      protocol: TCP
     to:
     {{ range $index, $privateSubnet := $privateSubnets }}
     - ipBlock:


### PR DESCRIPTION
This exporter scrapes the vault endpoint but the network policy is blocking traffic so scraping fails.