### PR TITLE
Change priorityClass to `system-node-critical` for the daemonset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Change priorityClass to `system-node-critical` for the daemonset.
+
 ## [2.1.1] - 2022-03-16
 
 ### Fixed

--- a/helm/cert-exporter/templates/daemonset.yaml
+++ b/helm/cert-exporter/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       # Tolerate all taints for observability
       - operator: "Exists"
       serviceAccountName: "{{ template "certExporter.daemonset.name" . }}"
-      priorityClassName: giantswarm-critical
+      priorityClassName: system-node-critical
       containers:
       - name: cert-exporter
         image: {{ include "certExporter.containerImage" . | quote }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/926

raise priority of the daemonset in order to avoid cluster-autoscaler not scaling out when a node is full and cert exporter not to be scheduled.