### PR TITLE
Enable cert-exporter to find certificates in CAPI clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 !vendor/**
 
 .vscode
-/.idea
 
 build
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !vendor/**
 
 .vscode
+/.idea
 
 build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Update k8s.io/apimachinery to v0.23.10.
 - Update k8s.io/client-go to v0.23.10.
 
+### Added
+
+- Add /etc/kubernetes/pki to --cert-paths flag in DaemonSet deployment.
+
 ## [2.2.0] - 2022-03-24
 
 ### Changed

--- a/exporters/cert/error.go
+++ b/exporters/cert/error.go
@@ -12,3 +12,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var certsPathNotFoundError = &microerror.Error{
+	Kind: "certsPathNotFound",
+}
+
+// IsCertsPathNotFound asserts certsPathNotFoundError.
+func IsCertsPathNotFound(err error) bool {
+	return microerror.Cause(err) == certsPathNotFoundError
+}

--- a/exporters/cert/exporter.go
+++ b/exporters/cert/exporter.go
@@ -29,11 +29,20 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.logger.Log("info", "start collecting metrics")
 
 	// Check every path.
+	certsPathNotFoundErrorCount := 0
 	for _, p := range e.paths {
 		err := e.collectPath(ch, p)
-		if err != nil {
+		if IsCertsPathNotFound(err) {
+			certsPathNotFoundErrorCount++
+		} else if err != nil {
 			e.logger.Log("error", microerror.Mask(err))
 		}
+	}
+
+	// Check if we found at least one certificates directory
+	foundCertsPaths := len(e.paths) - certsPathNotFoundErrorCount
+	if foundCertsPaths == 0 {
+		e.logger.Log("error", "at least one certificates path must exist")
 	}
 
 	e.logger.Log("info", "stop collecting metrics")
@@ -42,8 +51,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 func (e *Exporter) collectPath(ch chan<- prometheus.Metric, path string) error {
 	ok, err := afero.DirExists(e.fs, path)
 	if !ok {
-		e.logger.Log("error", microerror.Maskf(invalidConfigError, fmt.Sprintf("folder %s with certs has to exist", path)))
-		return nil
+		return microerror.Maskf(certsPathNotFoundError, fmt.Sprintf("folder %s with certs has to exist", path))
 	}
 	if err != nil {
 		e.logger.Log("error", microerror.Mask(err))

--- a/exporters/cert/exporter.go
+++ b/exporters/cert/exporter.go
@@ -26,7 +26,7 @@ type Exporter struct {
 }
 
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-	e.logger.Log("info", "start collecting metrics")
+	e.logger.Log("info", fmt.Sprintf("start collecting metrics %s", strings.Join(e.paths, ",")))
 
 	// Check every path.
 	certsPathNotFoundErrorCount := 0

--- a/exporters/cert/exporter.go
+++ b/exporters/cert/exporter.go
@@ -59,6 +59,7 @@ func (e *Exporter) collectPath(ch chan<- prometheus.Metric, path string) error {
 	}
 	err = afero.Walk(e.fs, path, func(fpath string, info os.FileInfo, err error) error {
 		if !info.IsDir() {
+			e.logger.Log("debug", fmt.Sprintf("checking cert %s", fpath))
 			file, err := afero.ReadFile(e.fs, fpath)
 			if err != nil {
 				e.logger.Log("error", microerror.Mask(err))
@@ -90,6 +91,8 @@ func (e *Exporter) collectPath(ch chan<- prometheus.Metric, path string) error {
 			e.logger.Log("info", fmt.Sprintf("added %s to the metrics", fpath))
 
 		}
+
+		e.logger.Log("debug", fmt.Sprintf("found cert path %s", path))
 		return nil
 	})
 	if err != nil {

--- a/exporters/cert/exporter.go
+++ b/exporters/cert/exporter.go
@@ -26,14 +26,16 @@ type Exporter struct {
 }
 
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-	e.logger.Log("info", fmt.Sprintf("start collecting metrics %s", strings.Join(e.paths, ",")))
+	e.logger.Log("info", fmt.Sprintf("start collecting metrics %s", strings.Join(e.paths, ";")))
 
 	// Check every path.
 	certsPathNotFoundErrorCount := 0
 	for _, p := range e.paths {
+		e.logger.Log("debug", fmt.Sprintf("checking cert path %s", p))
 		err := e.collectPath(ch, p)
 		if IsCertsPathNotFound(err) {
 			certsPathNotFoundErrorCount++
+			e.logger.Log("debug", fmt.Sprintf("cert path not found %s", p))
 		} else if err != nil {
 			e.logger.Log("error", microerror.Mask(err))
 		}

--- a/helm/cert-exporter/templates/daemonset.yaml
+++ b/helm/cert-exporter/templates/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         - --monitor-secrets={{ .Values.config.daemonset.monitorSecrets }}
         - --monitor-certificates={{ .Values.config.daemonset.monitorCertificates }}
         - --monitor-files={{ .Values.config.daemonset.monitorFiles }}
-        - --cert-paths={{ default "/etc/kubernetes/ssl" .Values.exporter.certPath }}
+        - --cert-paths={{ default "/etc/kubernetes/ssl,/etc/kubernetes/pki" .Values.exporter.certPath }}
         {{ if ne .Values.exporter.tokenPath "" }}
         - --token-path={{ .Values.exporter.tokenPath }}
         {{ end }}

--- a/helm/cert-exporter/templates/daemonset.yaml
+++ b/helm/cert-exporter/templates/daemonset.yaml
@@ -56,6 +56,9 @@ spec:
         - mountPath: {{ default "/etc/kubernetes/ssl" .Values.exporter.certPath }}
           name: certs-volume
           readOnly: true
+        - mountPath: {{ default "/etc/kubernetes/pki" .Values.exporter.capiCertPath }}
+          name: capi-certs-volume
+          readOnly: true
         {{ if ne .Values.exporter.tokenPath "" }}
         - mountPath: {{ .Values.exporter.tokenPath }}
           name: tokens-volume
@@ -68,6 +71,9 @@ spec:
       - name: certs-volume
         hostPath:
           path: {{ default "/etc/kubernetes/ssl" .Values.exporter.certPath }}
+      - name: capi-certs-volume
+        hostPath:
+          path: {{ default "/etc/kubernetes/pki" .Values.exporter.capiCertPath }}
       {{ if ne .Values.exporter.tokenPath "" }}
       - name: tokens-volume
         hostPath:

--- a/helm/cert-exporter/templates/psp.yaml
+++ b/helm/cert-exporter/templates/psp.yaml
@@ -32,6 +32,8 @@ spec:
     readOnly: true
   - pathPrefix: {{ default "/etc/kubernetes/ssl" .Values.exporter.certPath }}
     readOnly: true
+  - pathPrefix: {{ default "/etc/kubernetes/pki" .Values.exporter.capiCertPath }}
+    readOnly: true
   {{ if ne .Values.exporter.tokenPath "" }}
   - pathPrefix: {{ .Values.exporter.tokenPath }}
     readOnly: true

--- a/helm/cert-exporter/values.schema.json
+++ b/helm/cert-exporter/values.schema.json
@@ -38,6 +38,9 @@
         "exporter": {
             "type": "object",
             "properties": {
+                "capiCertPath": {
+                    "type": "string"
+                },
                 "certPath": {
                     "type": "string"
                 },

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -10,6 +10,7 @@ config:
 
 exporter:
   certPath: ""
+  capiCertPath: ""
   tokenPath: ""
 
 image:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1296

This is achieved by adding `/etc/kubernetes/pki` to `--cert-paths` flag in DaemonSet deployment, so that cert-exporter will search for certificates in that directory as well.

`/etc/kubernetes/pki` is Kubeadm's default directory for certificates.