### PR TITLE
- Disable PSPs for k8s 1.25 and newer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Update icon
+- Disable PSPs for k8s 1.25 and newer.
 
 ## [2.4.0] - 2023-04-03
 

--- a/helm/cert-exporter/templates/psp-deployment.yaml
+++ b/helm/cert-exporter/templates/psp-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -30,3 +31,4 @@ spec:
   hostIPC: false
   hostPID: false
   readOnlyRootFilesystem: true
+{{- end }}

--- a/helm/cert-exporter/templates/psp.yaml
+++ b/helm/cert-exporter/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -42,3 +43,4 @@ spec:
   hostIPC: false
   hostPID: false
   readOnlyRootFilesystem: true
+{{- end }}


### PR DESCRIPTION
in k8s 1.25 there is no PodSecurityPolicy

this PR disables the PSP for 1.25