### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ orbs:
 # container of app-test-suite cannot work together
 jobs:
   test:
-    machine: true
+    machine:
+      image: ubuntu-2204:2023.07.2
     environment:
       KIND_VERSION: v0.11.1
       KUBERNETES_VERSION: v1.24.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ workflows:
           name: push-to-registries
           requires:
             - build
-            - hold-push-cert-exporter-to-aliyun-pr
           filters:
             tags:
               only: /^v.*/
@@ -75,15 +74,6 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-
-      - hold-push-cert-exporter-to-aliyun-pr:
-          type: approval
-          requires:
-            - build
-          # Needed to prevent job from being triggered on master branch.
-          filters:
-            branches:
-              ignore: master
 
       - architect/push-to-app-collection:
           context: architect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [2.8.4] - 2023-10-26
 
 ### Fixed

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -23,7 +23,7 @@ image:
   tag: ""
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 vaultAddress: ""
 


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
