### PR TITLE
Add certname annotation to secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add cert name to secret metric.
+
 ## [2.8.5] - 2024-01-08
 
 ### Changed

--- a/tests/ats/test_cert_exporter.py
+++ b/tests/ats/test_cert_exporter.py
@@ -300,7 +300,7 @@ def test_secret_metrics(
     deploy_metrics = retrieve_metrics(deployment_port)
     assert_metric(
         deploy_metrics,
-        f'{metric_name}{{name="{cert_name}",namespace="default",secretkey="tls.crt"}}',
+        f'{metric_name}{{certificatename="",name="{cert_name}",namespace="default",secretkey="tls.crt"}}',
         check_expiry(expected_expiry),
     )
 

--- a/tests/ats/test_cert_exporter.py
+++ b/tests/ats/test_cert_exporter.py
@@ -297,7 +297,6 @@ def test_secret_metrics(
 
     # request from deployment port
     deploy_metrics = retrieve_metrics(deployment_port)
-    print("Deploy Metrics:", deploy_metrics)
     assert_metric(
         deploy_metrics,
         f'{metric_name}{{certificatename="",name="{cert_name}",namespace="default",secretkey="tls.crt"}}',

--- a/tests/ats/test_cert_exporter.py
+++ b/tests/ats/test_cert_exporter.py
@@ -297,6 +297,7 @@ def test_secret_metrics(
 
     # request from deployment port
     deploy_metrics = retrieve_metrics(deployment_port)
+    print("Deploy Metrics:", deploy_metrics)
     assert_metric(
         deploy_metrics,
         f'{metric_name}{{certificatename="",name="{cert_name}",namespace="default",secretkey="tls.crt"}}',
@@ -305,7 +306,6 @@ def test_secret_metrics(
 
     # request from daemonset port
     ds_metrics = retrieve_metrics(daemonset_port)
-    print("Daemonset Metrics:", ds_metrics)
     assert len([m for m in ds_metrics if m.startswith(metric_name)]) == 0
 
     # cleanup

--- a/tests/ats/test_cert_exporter.py
+++ b/tests/ats/test_cert_exporter.py
@@ -139,7 +139,6 @@ def retrieve_metrics(port: int) -> List[str]:
     assert r.status_code == 200
 
     raw_metrics = r.text
-    print(raw_metrics)
     metrics_lines = [
         line for line in raw_metrics.splitlines() if not line.startswith("#")
     ]
@@ -305,8 +304,8 @@ def test_secret_metrics(
     )
 
     # request from daemonset port
-    print("Daemonset Metrics:", ds_metrics)
     ds_metrics = retrieve_metrics(daemonset_port)
+    print("Daemonset Metrics:", ds_metrics)
     assert len([m for m in ds_metrics if m.startswith(metric_name)]) == 0
 
     # cleanup

--- a/tests/ats/test_cert_exporter.py
+++ b/tests/ats/test_cert_exporter.py
@@ -139,7 +139,7 @@ def retrieve_metrics(port: int) -> List[str]:
     assert r.status_code == 200
 
     raw_metrics = r.text
-
+    print(raw_metrics)
     metrics_lines = [
         line for line in raw_metrics.splitlines() if not line.startswith("#")
     ]
@@ -305,6 +305,7 @@ def test_secret_metrics(
     )
 
     # request from daemonset port
+    print("Daemonset Metrics:", ds_metrics)
     ds_metrics = retrieve_metrics(daemonset_port)
     assert len([m for m in ds_metrics if m.startswith(metric_name)]) == 0
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/29024

This will allow us to compare if secret and certificate are both present. The idea is to use the annotation from the secret to verify the certificate matches even when they not using the same name.

Tested in `gauss`:

<img width="2550" alt="image" src="https://github.com/giantswarm/cert-exporter/assets/1936982/7a34ae2c-3a0c-4de7-b08f-640c88dd3b4e">
