### PR TITLE
Chart: Update PolicyExceptions to v2beta1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Update PolicyExceptions to v2beta1. ([#358](https://github.com/giantswarm/cert-exporter/pull/358))
+
 ## [2.9.0] - 2024-01-12
 
 ### Added

--- a/helm/cert-exporter/templates/daemonset-policy-exceptions.yaml
+++ b/helm/cert-exporter/templates/daemonset-policy-exceptions.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
 {{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ template "certExporter.daemonset.name" . }}-policy-exceptions

--- a/helm/cert-exporter/templates/deployment-policy-exceptions.yaml
+++ b/helm/cert-exporter/templates/deployment-policy-exceptions.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
 {{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ template "certExporter.deployment.name" . }}-policy-exceptions


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.