### PR TITLE
Add value to toggle creation of Daemonset resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Add value to toggle creation of Daemonset resources.
+
 ## [2.9.10] - 2025-10-02
 
 ### Changed

--- a/helm/cert-exporter/templates/ciliumnetworkpolicy.yaml
+++ b/helm/cert-exporter/templates/ciliumnetworkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.enabled }}
 {{ if .Values.ciliumNetworkPolicy.enabled }}
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
@@ -17,4 +18,5 @@ spec:
   ingress:
     - fromEntities:
         - cluster
+{{ end }}
 {{ end }}

--- a/helm/cert-exporter/templates/daemonset-policy-exceptions.yaml
+++ b/helm/cert-exporter/templates/daemonset-policy-exceptions.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.enabled }}
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
 {{- if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" }}
 apiVersion: kyverno.io/v2
@@ -51,5 +52,6 @@ spec:
         - {{ .Release.Namespace }}
         names:
         - {{ template "certExporter.daemonset.name" . }}*
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cert-exporter/templates/daemonset.yaml
+++ b/helm/cert-exporter/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -77,3 +78,4 @@ spec:
       - name: ca-certs
         hostPath:
           path: /etc/ssl/certs/
+{{- end }}

--- a/helm/cert-exporter/templates/np.yaml
+++ b/helm/cert-exporter/templates/np.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.enabled }}
 {{ $privateSubnets := list "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" }}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -48,3 +49,4 @@ spec:
     - ipBlock:
         cidr: {{ $privateSubnet }}
     {{- end }}
+{{- end }}

--- a/helm/cert-exporter/templates/psp.yaml
+++ b/helm/cert-exporter/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.enabled }}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -43,4 +44,5 @@ spec:
   hostIPC: false
   hostPID: false
   readOnlyRootFilesystem: true
+{{- end }}
 {{- end }}

--- a/helm/cert-exporter/templates/rbac.yaml
+++ b/helm/cert-exporter/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.enabled }}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -29,4 +30,5 @@ subjects:
   - kind: ServiceAccount
     name: "{{ template "certExporter.daemonset.name" . }}"
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/helm/cert-exporter/templates/service-account.yaml
+++ b/helm/cert-exporter/templates/service-account.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "certExporter.daemonset.labels" . | nindent 4 }}
+{{- end }}

--- a/helm/cert-exporter/templates/service.yaml
+++ b/helm/cert-exporter/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
     targetPort: cert-exporter
   selector:
     {{- include "certExporter.daemonset.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/cert-exporter/templates/servicemonitor.yaml
+++ b/helm/cert-exporter/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.enabled }}
 {{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -32,4 +33,5 @@ spec:
   selector:
     matchLabels:
       {{- include "certExporter.daemonset.matchLabels" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/helm/cert-exporter/values.schema.json
+++ b/helm/cert-exporter/values.schema.json
@@ -46,6 +46,10 @@
         "daemonset": {
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true
+                },
                 "resources": {
                     "type": "object",
                     "properties": {

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -57,6 +57,7 @@ deployment:
       memory: 150Mi
 
 daemonset:
+  enabled: true
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
this PR enables the toggling of the daemonset components. when deploying on EKS we do not need to monitor the node's certificates as these are handled by AWS.
