### PR TITLE
Build multi-arch (amd64 + arm64) container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,9 @@ workflows:
   build:
     jobs:
       - architect/go-build:
-          name: build
+          matrix:
+            parameters:
+              architecture: ["linux/amd64", "linux/arm64"]
           binary: cert-exporter
           filters:
             branches:
@@ -41,8 +43,9 @@ workflows:
       - architect/push-to-registries:
           name: push-to-registries
           context: architect
+          multiarch: true
           requires:
-            - build
+            - architect/go-build
           filters:
             branches:
               ignore:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Build and publish a multi-arch (linux/amd64 + linux/arm64) container image. Required so the cert-exporter daemonset can run on Graviton/arm64 nodepools without `exec format error`.
+
 ## [2.10.1] - 2026-04-08
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
+FROM --platform=$BUILDPLATFORM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm AS prep
+USER root
+RUN apk add --no-cache ca-certificates
+
 FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm
 
-USER root
-
-RUN apk add --no-cache ca-certificates
+COPY --from=prep /etc/ssl/certs /etc/ssl/certs
+COPY --from=prep /usr/share/ca-certificates /usr/share/ca-certificates
 
 USER giantswarm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --no-cache ca-certificates
 
 USER giantswarm
 
-COPY ./cert-exporter /cert-exporter
+ARG TARGETARCH
+COPY ./cert-exporter-linux-${TARGETARCH} /cert-exporter
 
 ENTRYPOINT ["/cert-exporter"]


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35827

Builds and publishes the cert-exporter container image for both `linux/amd64` and `linux/arm64`. Today the image is amd64-only, so the cert-exporter daemonset crashes on Graviton/arm64 nodes with `exec /cert-exporter: exec format error`.

Pattern aligned with [`giantswarm/architect`](https://github.com/giantswarm/architect/blob/master/.circleci/config.yml):

- `architect/go-build` runs as a matrix over `linux/amd64` and `linux/arm64`, producing `cert-exporter-linux-amd64` and `cert-exporter-linux-arm64` in the workspace.
- `architect/push-to-registries` set to `multiarch: true`. CircleCI fan-in via `requires: - architect/go-build` waits for both matrix entries.
- Dockerfile picks the right binary at build time via `ARG TARGETARCH` (set per-platform by `docker buildx`).

Verified failure on graveler-nick: `cert-exporter-daemonset-d2z6q` on arm64 m7g.xlarge node, CrashLoopBackOff with `exec format error`. After this lands and a release is cut, the daemonset will start cleanly on arm64.
