### PR TITLE
Use descriptive go-build-cert-exporter prefix on matrix jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ workflows:
           matrix:
             parameters:
               architecture: ["linux/amd64", "linux/arm64"]
+          name: go-build-cert-exporter-<<matrix.architecture>>
           binary: cert-exporter
           filters:
             branches:
@@ -45,7 +46,8 @@ workflows:
           context: architect
           multiarch: true
           requires:
-            - architect/go-build
+            - go-build-cert-exporter-linux/amd64
+            - go-build-cert-exporter-linux/arm64
           filters:
             branches:
               ignore:


### PR DESCRIPTION
Follow-up to #564.

Aligns the matrix-generated job names with the descriptive prefix pattern used elsewhere at GS (e.g. `giantswarm/net-exporter`):

- `go-build-cert-exporter-linux/amd64`
- `go-build-cert-exporter-linux/arm64`

Two reasons:

1. **Discoverability** in cross-repo CI dashboards — generic `architect/go-build` collides visually when scanning multiple repos.
2. **Branch protection** — repos that pin specific check names need explicit per-arch entries instead of relying on `architect/go-build` fan-in.

Will need a corresponding update to branch protection rules:

- Remove: `ci/circleci: build` (legacy)
- Add: `ci/circleci: go-build-cert-exporter-linux/amd64`
- Add: `ci/circleci: go-build-cert-exporter-linux/arm64`
