### PR TITLE
fix: Fix metric collision from concatenated certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Add a `serialnumber` label to the `cert_exporter_not_after` and `cert_exporter_secret_not_after` metrics so concatenated certificates no longer collide into identical series. The collision made the registry fail `Gather()`, which blanked out the entire `/metrics` endpoint (regression from v2.10.1).
+- Serve `/metrics` with `ContinueOnError` so a single problematic metric can no longer fail the whole scrape.
+
 ## [2.11.0] - 2026-05-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Exposes three metrics to Prometheus regarding certificates/tokens:
 
 ## `cert_exporter_not_after`
 
-Timestamp after which the cert is invalid (for certificate files mounted from the host filesystem).
+Timestamp after which the cert is invalid (for certificate files mounted from the host filesystem). When a file contains multiple concatenated certificates, one series is emitted per certificate, distinguished by the `serialnumber` label.
 
 ## `cert_exporter_secret_not_after`
 
-Timestamp after which the cert is invalid (for certificates stored in Kubernetes secrets).
+Timestamp after which the cert is invalid (for certificates stored in Kubernetes secrets). When a secret key contains multiple concatenated certificates, one series is emitted per certificate, distinguished by the `serialnumber` label.
 
 ## `cert_exporter_token_not_after`
 

--- a/exporters/cert/exporter.go
+++ b/exporters/cert/exporter.go
@@ -89,7 +89,8 @@ func (e *Exporter) collectPath(ch chan<- prometheus.Metric, path string) error {
 
 				for _, cert := range certs {
 					timestamp := float64(cert.NotAfter.Unix())
-					ch <- prometheus.MustNewConstMetric(e.cert, prometheus.GaugeValue, timestamp, fpath)
+					serialNumber := fmt.Sprintf("%x", cert.SerialNumber)
+					ch <- prometheus.MustNewConstMetric(e.cert, prometheus.GaugeValue, timestamp, fpath, serialNumber)
 				}
 			}
 			e.logger.Log("info", fmt.Sprintf("added %s to the metrics", fpath))
@@ -137,6 +138,7 @@ func New(config Config) (*Exporter, error) {
 			"Timestamp after which the cert is invalid.",
 			[]string{
 				"path",
+				"serialnumber",
 			},
 			nil,
 		),

--- a/exporters/cert/exporter_test.go
+++ b/exporters/cert/exporter_test.go
@@ -27,7 +27,7 @@ func newTestExporter(t *testing.T, fs afero.Fs, paths []string) *Exporter {
 		cert: prometheus.NewDesc(
 			prometheus.BuildFQName("cert_exporter", "", "not_after"),
 			"Timestamp after which the cert is invalid.",
-			[]string{"path"},
+			[]string{"path", "serialnumber"},
 			nil,
 		),
 		fs:     fs,
@@ -45,7 +45,9 @@ func generateSelfSignedCertPEM(t *testing.T, notAfter time.Time) []byte {
 	}
 
 	template := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		// Derive a unique serial from the expiry so concatenated certs in a
+		// test get distinct serial numbers, mirroring real-world certificates.
+		SerialNumber: big.NewInt(notAfter.Unix()),
 		NotBefore:    time.Now().Add(-1 * time.Hour),
 		NotAfter:     notAfter,
 	}
@@ -110,6 +112,40 @@ func TestCollectPath_MultipleCertsInSameFile(t *testing.T) {
 
 	if len(metrics) != 2 {
 		t.Fatalf("expected 2 metrics for concatenated certs, got %d", len(metrics))
+	}
+}
+
+// TestGather_MultipleCertsInSameFile guards against the regression where two
+// certs concatenated in a single file produced metrics with identical label
+// sets, causing Gather() to fail and blanking out the whole scrape.
+func TestGather_MultipleCertsInSameFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	cert1 := generateSelfSignedCertPEM(t, time.Now().Add(1*time.Hour))
+	cert2 := generateSelfSignedCertPEM(t, time.Now().Add(48*time.Hour))
+	combined := append(cert1, cert2...)
+
+	_ = fs.MkdirAll("/certs", 0755)
+	_ = afero.WriteFile(fs, "/certs/tls.crt", combined, 0644)
+
+	e := newTestExporter(t, fs, []string{"/certs"})
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(e); err != nil {
+		t.Fatal(err)
+	}
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() failed (duplicate series regression): %v", err)
+	}
+
+	var series int
+	for _, mf := range mfs {
+		series += len(mf.GetMetric())
+	}
+	if series != 2 {
+		t.Fatalf("expected 2 distinct series for concatenated certs, got %d", series)
 	}
 }
 

--- a/exporters/secret/exporter.go
+++ b/exporters/secret/exporter.go
@@ -102,7 +102,8 @@ func (e *Exporter) calculateExpiry(ch chan<- prometheus.Metric, secret v1.Secret
 
 			for _, cert := range certs {
 				timestamp := float64(cert.NotAfter.Unix())
-				ch <- prometheus.MustNewConstMetric(e.cert, prometheus.GaugeValue, timestamp, secretName, secretNamespace, certKey, certName)
+				serialNumber := fmt.Sprintf("%x", cert.SerialNumber)
+				ch <- prometheus.MustNewConstMetric(e.cert, prometheus.GaugeValue, timestamp, secretName, secretNamespace, certKey, certName, serialNumber)
 			}
 		}
 	}
@@ -155,6 +156,7 @@ func New(config Config) (*Exporter, error) {
 				"namespace",
 				"secretkey",
 				"certificatename",
+				"serialnumber",
 			},
 			nil,
 		),

--- a/exporters/secret/exporter_test.go
+++ b/exporters/secret/exporter_test.go
@@ -29,7 +29,7 @@ func newTestExporter(t *testing.T) *Exporter {
 		cert: prometheus.NewDesc(
 			prometheus.BuildFQName("cert_exporter", "secret", "not_after"),
 			"Timestamp after which the cert is invalid.",
-			[]string{"name", "namespace", "secretkey", "certificatename"},
+			[]string{"name", "namespace", "secretkey", "certificatename", "serialnumber"},
 			nil,
 		),
 		ctx:    context.Background(),
@@ -46,7 +46,9 @@ func generateSelfSignedCertPEM(t *testing.T, notAfter time.Time) []byte {
 	}
 
 	template := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		// Derive a unique serial from the expiry so concatenated certs in a
+		// test get distinct serial numbers, mirroring real-world certificates.
+		SerialNumber: big.NewInt(notAfter.Unix()),
 		NotBefore:    time.Now().Add(-1 * time.Hour),
 		NotAfter:     notAfter,
 	}
@@ -131,6 +133,51 @@ func TestCalculateExpiry_MultipleCertsInSameKey(t *testing.T) {
 	// tls.crt has 2 certs, ca.crt has 1 = 3 total
 	if len(metrics) != 3 {
 		t.Fatalf("expected 3 metrics for concatenated certs, got %d", len(metrics))
+	}
+}
+
+// secretCollector adapts calculateExpiry to the prometheus.Collector interface
+// so the metrics can be exercised through a real registry Gather(), which is
+// where duplicate-series collisions surface (a plain channel read does not).
+type secretCollector struct {
+	e      *Exporter
+	secret v1.Secret
+}
+
+func (c *secretCollector) Describe(ch chan<- *prometheus.Desc) { ch <- c.e.cert }
+func (c *secretCollector) Collect(ch chan<- prometheus.Metric) { _ = c.e.calculateExpiry(ch, c.secret) }
+
+// TestGather_MultipleCertsInSameKey guards against the regression where two
+// certs concatenated in a single secret key produced metrics with identical
+// label sets, causing Gather() to fail and blanking out the whole scrape.
+func TestGather_MultipleCertsInSameKey(t *testing.T) {
+	e := newTestExporter(t)
+
+	certPEM1 := generateSelfSignedCertPEM(t, time.Now().Add(1*time.Hour))
+	certPEM2 := generateSelfSignedCertPEM(t, time.Now().Add(48*time.Hour))
+	combined := append(certPEM1, certPEM2...)
+
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kyverno-webhook", Namespace: "kyverno"},
+		Data:       map[string][]byte{"tls.crt": combined},
+	}
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(&secretCollector{e: e, secret: secret}); err != nil {
+		t.Fatal(err)
+	}
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() failed (duplicate series regression): %v", err)
+	}
+
+	var series int
+	for _, mf := range mfs {
+		series += len(mf.GetMetric())
+	}
+	if series != 2 {
+		t.Fatalf("expected 2 distinct series for concatenated certs, got %d", series)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -114,6 +114,10 @@ func main() {
 		prometheus.MustRegister(crExporter)
 	}
 
-	http.Handle("/metrics", promhttp.Handler())
+	// Use ContinueOnError so that a single problematic metric (e.g. a duplicate
+	// series) cannot fail the whole scrape and blank out all other metrics.
+	http.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.ContinueOnError,
+	}))
 	http.ListenAndServe(address, nil) // nolint:errcheck,gosec
 }

--- a/tests/ats/test_cert_exporter.py
+++ b/tests/ats/test_cert_exporter.py
@@ -237,10 +237,13 @@ def test_file_certificate_metrics(
     time.sleep(5)
 
     # request from daemonset port
+    # Match on the label prefix (no closing brace) so this works against both
+    # the previous chart and the new one, which appends a serialnumber label.
+    # The upgrade scenario runs these tests against the released chart too.
     ds_metrics = retrieve_metrics(daemonset_port)
     assert_metric(
         ds_metrics,
-        f'{metric_name}{{path="/certs/{cert_name}.crt"}}',
+        f'{metric_name}{{path="/certs/{cert_name}.crt"',
         check_expiry(expected_expiry),
     )
 
@@ -296,10 +299,13 @@ def test_secret_metrics(
     time.sleep(5)
 
     # request from deployment port
+    # Match on the label prefix (no closing brace) so this works against both
+    # the previous chart and the new one, which appends a serialnumber label.
+    # The upgrade scenario runs these tests against the released chart too.
     deploy_metrics = retrieve_metrics(deployment_port)
     assert_metric(
         deploy_metrics,
-        f'{metric_name}{{certificatename="",name="{cert_name}",namespace="default",secretkey="tls.crt"}}',
+        f'{metric_name}{{certificatename="",name="{cert_name}",namespace="default",secretkey="tls.crt"',
         check_expiry(expected_expiry),
     )
 


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C02EVLE9W/p1782466872487459

PR #550 (v2.10.1) started emitting one metric per certificate when a secret key or file contains concatenated certs. Those samples shared an identical label set, so the registry failed `Gather()` and `promhttp.Handler()` (default `HTTPErrorOnError`) returned HTTP 500 — blanking the entire `/metrics` endpoint. This is why `cert_exporter_secret_not_after` disappeared after the upgrade.

- Add a `serialnumber` label so each certificate is a distinct series.
- Serve `/metrics` with `ContinueOnError` as a safety net.
- Add `Gather()`-based tests that catch the collision (the original tests only read the channel).