### PR TITLE
test: add regression tests for the metrics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Regression tests covering the v2.11.1 metrics endpoint fix: concatenated and repeated certificates in secrets and files, and an endpoint level test asserting `/metrics` keeps returning 200 and serving the remaining metrics when a duplicate series is emitted.
+- ATS: End to end test for a TLS secret whose `tls.crt` holds a concatenated certificate chain.
+
+### Changed
+
+- ATS: `cert_gen` now sets a certificate serial number, which defaulted to `0` for every generated certificate.
+
 ## [2.11.2] - 2026-07-28
 
 ### Changed

--- a/exporters/cert/exporter.go
+++ b/exporters/cert/exporter.go
@@ -113,6 +113,21 @@ func (e *Exporter) fileIsPrivateKey(f []byte) bool {
 	return strings.Contains(string(f), "RSA PRIVATE KEY")
 }
 
+// newCertDesc describes the exported metric. Kept separate from New so tests can
+// assert against the real label set instead of a copy of it. The serialnumber
+// label is what keeps concatenated certificates from colliding into one series.
+func newCertDesc() *prometheus.Desc {
+	return prometheus.NewDesc(
+		prometheus.BuildFQName("cert_exporter", "", "not_after"),
+		"Timestamp after which the cert is invalid.",
+		[]string{
+			"path",
+			"serialnumber",
+		},
+		nil,
+	)
+}
+
 func DefaultConfig() Config {
 	return Config{
 		Paths: []string{},
@@ -133,15 +148,7 @@ func New(config Config) (*Exporter, error) {
 	logger.Log("info", "creating new exporter")
 
 	return &Exporter{
-		cert: prometheus.NewDesc(
-			prometheus.BuildFQName("cert_exporter", "", "not_after"),
-			"Timestamp after which the cert is invalid.",
-			[]string{
-				"path",
-				"serialnumber",
-			},
-			nil,
-		),
+		cert:   newCertDesc(),
 		fs:     fs,
 		logger: logger,
 		paths:  config.Paths,

--- a/exporters/cert/exporter_test.go
+++ b/exporters/cert/exporter_test.go
@@ -7,13 +7,19 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/afero"
 )
+
+const metricName = "cert_exporter_not_after"
 
 func newTestExporter(t *testing.T, fs afero.Fs, paths []string) *Exporter {
 	t.Helper()
@@ -24,12 +30,9 @@ func newTestExporter(t *testing.T, fs afero.Fs, paths []string) *Exporter {
 	}
 
 	return &Exporter{
-		cert: prometheus.NewDesc(
-			prometheus.BuildFQName("cert_exporter", "", "not_after"),
-			"Timestamp after which the cert is invalid.",
-			[]string{"path", "serialnumber"},
-			nil,
-		),
+		// The production descriptor, so a change to the exported labels is
+		// caught here instead of silently passing against a copy.
+		cert:   newCertDesc(),
 		fs:     fs,
 		logger: logger,
 		paths:  paths,
@@ -146,6 +149,124 @@ func TestGather_MultipleCertsInSameFile(t *testing.T) {
 	}
 	if series != 2 {
 		t.Fatalf("expected 2 distinct series for concatenated certs, got %d", series)
+	}
+}
+
+// serveMetrics renders a registry through the same handler configuration
+// main.go uses, so tests can assert what a Prometheus scrape actually receives.
+func serveMetrics(t *testing.T, reg *prometheus.Registry) (int, string) {
+	t.Helper()
+
+	h := promhttp.HandlerFor(reg, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.ContinueOnError,
+	})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	return rec.Code, rec.Body.String()
+}
+
+func samplesFor(body, path string) []string {
+	var samples []string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, metricName) && strings.Contains(line, `path="`+path+`"`) {
+			samples = append(samples, line)
+		}
+	}
+
+	return samples
+}
+
+// TestScrape_DuplicateIdenticalCertInSameFile covers a file holding the *same*
+// certificate twice, which the serialnumber label cannot tell apart. The scrape
+// must still succeed and report the certificate once.
+func TestScrape_DuplicateIdenticalCertInSameFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	certPEM := generateSelfSignedCertPEM(t, time.Now().Add(1*time.Hour))
+	duplicated := append(append([]byte{}, certPEM...), certPEM...)
+
+	_ = fs.MkdirAll("/certs", 0755)
+	_ = afero.WriteFile(fs, "/certs/tls.crt", duplicated, 0644)
+
+	e := newTestExporter(t, fs, []string{"/certs"})
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(e); err != nil {
+		t.Fatal(err)
+	}
+
+	code, body := serveMetrics(t, reg)
+	if code != http.StatusOK {
+		t.Fatalf("expected /metrics to return 200, got %d", code)
+	}
+
+	if got := len(samplesFor(body, "/certs/tls.crt")); got != 1 {
+		t.Fatalf("expected the duplicated certificate to be served once, got %d samples", got)
+	}
+}
+
+// TestGather_SameCertInTwoFiles makes sure the same certificate on two paths
+// still yields two series, because the path label keeps them distinct.
+func TestGather_SameCertInTwoFiles(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	certPEM := generateSelfSignedCertPEM(t, time.Now().Add(1*time.Hour))
+
+	_ = fs.MkdirAll("/certs", 0755)
+	_ = afero.WriteFile(fs, "/certs/tls.crt", certPEM, 0644)
+	_ = afero.WriteFile(fs, "/certs/ca.crt", certPEM, 0644)
+
+	e := newTestExporter(t, fs, []string{"/certs"})
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(e); err != nil {
+		t.Fatal(err)
+	}
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() failed: %v", err)
+	}
+
+	var series int
+	for _, mf := range mfs {
+		series += len(mf.GetMetric())
+	}
+	if series != 2 {
+		t.Fatalf("expected 1 series per file, got %d", series)
+	}
+}
+
+// TestScrape_DuplicateDoesNotHideOtherCerts is the core regression guard: a file
+// with duplicated certificates must not take the metrics of the other files down
+// with it. Losing those was the customer visible symptom, and it is what
+// ContinueOnError prevents.
+func TestScrape_DuplicateDoesNotHideOtherCerts(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	healthy := generateSelfSignedCertPEM(t, time.Now().Add(72*time.Hour))
+	broken := generateSelfSignedCertPEM(t, time.Now().Add(1*time.Hour))
+
+	_ = fs.MkdirAll("/certs", 0755)
+	_ = afero.WriteFile(fs, "/certs/healthy.crt", healthy, 0644)
+	_ = afero.WriteFile(fs, "/certs/duplicated.crt", append(append([]byte{}, broken...), broken...), 0644)
+
+	e := newTestExporter(t, fs, []string{"/certs"})
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(e); err != nil {
+		t.Fatal(err)
+	}
+
+	code, body := serveMetrics(t, reg)
+	if code != http.StatusOK {
+		t.Fatalf("expected /metrics to return 200 despite a duplicate series, got %d", code)
+	}
+
+	if got := len(samplesFor(body, "/certs/healthy.crt")); got != 1 {
+		t.Fatalf("expected the unrelated certificate to still be served, got %d samples", got)
 	}
 }
 

--- a/exporters/secret/exporter.go
+++ b/exporters/secret/exporter.go
@@ -34,6 +34,24 @@ type Exporter struct {
 	namespaces []string
 }
 
+// newCertDesc describes the exported metric. Kept separate from New so tests can
+// assert against the real label set instead of a copy of it. The serialnumber
+// label is what keeps concatenated certificates from colliding into one series.
+func newCertDesc() *prometheus.Desc {
+	return prometheus.NewDesc(
+		prometheus.BuildFQName("cert_exporter", "secret", "not_after"),
+		"Timestamp after which the cert is invalid.",
+		[]string{
+			"name",
+			"namespace",
+			"secretkey",
+			"certificatename",
+			"serialnumber",
+		},
+		nil,
+	)
+}
+
 func DefaultConfig() Config {
 	return Config{
 		Namespaces: []string{},
@@ -148,18 +166,7 @@ func New(config Config) (*Exporter, error) {
 	logger.Log("info", "creating new exporter")
 
 	return &Exporter{
-		cert: prometheus.NewDesc(
-			prometheus.BuildFQName("cert_exporter", "secret", "not_after"),
-			"Timestamp after which the cert is invalid.",
-			[]string{
-				"name",
-				"namespace",
-				"secretkey",
-				"certificatename",
-				"serialnumber",
-			},
-			nil,
-		),
+		cert:       newCertDesc(),
 		ctx:        ctx,
 		k8sClient:  k8sClient,
 		logger:     logger,

--- a/exporters/secret/exporter_test.go
+++ b/exporters/secret/exporter_test.go
@@ -8,14 +8,20 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const metricName = "cert_exporter_secret_not_after"
 
 func newTestExporter(t *testing.T) *Exporter {
 	t.Helper()
@@ -26,12 +32,9 @@ func newTestExporter(t *testing.T) *Exporter {
 	}
 
 	return &Exporter{
-		cert: prometheus.NewDesc(
-			prometheus.BuildFQName("cert_exporter", "secret", "not_after"),
-			"Timestamp after which the cert is invalid.",
-			[]string{"name", "namespace", "secretkey", "certificatename", "serialnumber"},
-			nil,
-		),
+		// The production descriptor, so a change to the exported labels is
+		// caught here instead of silently passing against a copy.
+		cert:   newCertDesc(),
 		ctx:    context.Background(),
 		logger: logger,
 	}
@@ -147,6 +150,20 @@ type secretCollector struct {
 func (c *secretCollector) Describe(ch chan<- *prometheus.Desc) { ch <- c.e.cert }
 func (c *secretCollector) Collect(ch chan<- prometheus.Metric) { _ = c.e.calculateExpiry(ch, c.secret) }
 
+// multiSecretCollector collects several secrets in one scrape, so a collision
+// caused by one secret can be observed against the metrics of the others.
+type multiSecretCollector struct {
+	e       *Exporter
+	secrets []v1.Secret
+}
+
+func (c *multiSecretCollector) Describe(ch chan<- *prometheus.Desc) { ch <- c.e.cert }
+func (c *multiSecretCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, s := range c.secrets {
+		_ = c.e.calculateExpiry(ch, s)
+	}
+}
+
 // TestGather_MultipleCertsInSameKey guards against the regression where two
 // certs concatenated in a single secret key produced metrics with identical
 // label sets, causing Gather() to fail and blanking out the whole scrape.
@@ -178,6 +195,165 @@ func TestGather_MultipleCertsInSameKey(t *testing.T) {
 	}
 	if series != 2 {
 		t.Fatalf("expected 2 distinct series for concatenated certs, got %d", series)
+	}
+}
+
+// serveMetrics renders a registry through the same handler configuration
+// main.go uses, so tests can assert what a Prometheus scrape actually receives.
+func serveMetrics(t *testing.T, reg *prometheus.Registry) (int, string) {
+	t.Helper()
+
+	h := promhttp.HandlerFor(reg, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.ContinueOnError,
+	})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	return rec.Code, rec.Body.String()
+}
+
+func samplesFor(body, secretName string) []string {
+	var samples []string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, metricName) && strings.Contains(line, `name="`+secretName+`"`) {
+			samples = append(samples, line)
+		}
+	}
+
+	return samples
+}
+
+// TestScrape_DuplicateIdenticalCertInSameKey covers a secret key holding the
+// *same* certificate twice, which the serialnumber label cannot tell apart. The
+// scrape must still succeed and report the certificate once.
+func TestScrape_DuplicateIdenticalCertInSameKey(t *testing.T) {
+	e := newTestExporter(t)
+
+	certPEM := generateSelfSignedCertPEM(t, time.Now().Add(1*time.Hour))
+	duplicated := append(append([]byte{}, certPEM...), certPEM...)
+
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "duplicated-chain", Namespace: "default"},
+		Data:       map[string][]byte{"tls.crt": duplicated},
+	}
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(&secretCollector{e: e, secret: secret}); err != nil {
+		t.Fatal(err)
+	}
+
+	code, body := serveMetrics(t, reg)
+	if code != http.StatusOK {
+		t.Fatalf("expected /metrics to return 200, got %d", code)
+	}
+
+	if got := len(samplesFor(body, "duplicated-chain")); got != 1 {
+		t.Fatalf("expected the duplicated certificate to be served once, got %d samples", got)
+	}
+}
+
+// TestGather_SameCertInBothKeys makes sure a certificate stored under two keys
+// is still reported twice: cert-manager routinely stores the CA in both ca.crt
+// and tls.crt, and the secretkey label keeps those samples distinct.
+func TestGather_SameCertInBothKeys(t *testing.T) {
+	e := newTestExporter(t)
+
+	certPEM := generateSelfSignedCertPEM(t, time.Now().Add(1*time.Hour))
+
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-ca", Namespace: "default"},
+		Data: map[string][]byte{
+			"tls.crt": certPEM,
+			"ca.crt":  certPEM,
+		},
+	}
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(&secretCollector{e: e, secret: secret}); err != nil {
+		t.Fatal(err)
+	}
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() failed: %v", err)
+	}
+
+	var series int
+	for _, mf := range mfs {
+		series += len(mf.GetMetric())
+	}
+	if series != 2 {
+		t.Fatalf("expected 1 series per secret key, got %d", series)
+	}
+}
+
+// TestGather_LeafPlusCA models a real chain: a leaf plus its issuing CA
+// concatenated in tls.crt. Both must be reported, which is the v2.11.1 fix for
+// the original regression.
+func TestGather_LeafPlusCA(t *testing.T) {
+	e := newTestExporter(t)
+
+	leaf := generateSelfSignedCertPEM(t, time.Now().Add(1*time.Hour))
+	ca := generateSelfSignedCertPEM(t, time.Now().Add(48*time.Hour))
+
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "leaf-and-ca", Namespace: "default"},
+		Data:       map[string][]byte{"tls.crt": append(append([]byte{}, leaf...), ca...)},
+	}
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(&secretCollector{e: e, secret: secret}); err != nil {
+		t.Fatal(err)
+	}
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() failed (duplicate series regression): %v", err)
+	}
+
+	var series int
+	for _, mf := range mfs {
+		series += len(mf.GetMetric())
+	}
+	if series != 2 {
+		t.Fatalf("expected 2 distinct series (leaf + CA), got %d", series)
+	}
+}
+
+// TestScrape_DuplicateDoesNotHideOtherSecrets is the core regression guard: a
+// secret carrying duplicated certificates must not take the metrics of
+// unrelated secrets down with it. Losing those was the customer visible
+// symptom, and it is what ContinueOnError prevents.
+func TestScrape_DuplicateDoesNotHideOtherSecrets(t *testing.T) {
+	e := newTestExporter(t)
+
+	healthy := generateSelfSignedCertPEM(t, time.Now().Add(72*time.Hour))
+	broken := generateSelfSignedCertPEM(t, time.Now().Add(1*time.Hour))
+
+	secrets := []v1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "healthy", Namespace: "default"},
+			Data:       map[string][]byte{"tls.crt": healthy},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "duplicated", Namespace: "default"},
+			Data:       map[string][]byte{"tls.crt": append(append([]byte{}, broken...), broken...)},
+		},
+	}
+
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(&multiSecretCollector{e: e, secrets: secrets}); err != nil {
+		t.Fatal(err)
+	}
+
+	code, body := serveMetrics(t, reg)
+	if code != http.StatusOK {
+		t.Fatalf("expected /metrics to return 200 despite a duplicate series, got %d", code)
+	}
+
+	if got := len(samplesFor(body, "healthy")); got != 1 {
+		t.Fatalf("expected the unrelated secret to still be served, got %d samples", got)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -19,6 +19,15 @@ import (
 	"github.com/giantswarm/cert-exporter/pkg/project"
 )
 
+// metricsHandler serves /metrics with ContinueOnError so that a single
+// problematic metric (e.g. a duplicate series) cannot fail the whole scrape and
+// blank out all other metrics.
+func metricsHandler(gatherer prometheus.Gatherer) http.Handler {
+	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.ContinueOnError,
+	})
+}
+
 func main() {
 	// Print version.
 	if (len(os.Args) > 1) && (os.Args[1] == "version") {
@@ -114,10 +123,6 @@ func main() {
 		prometheus.MustRegister(crExporter)
 	}
 
-	// Use ContinueOnError so that a single problematic metric (e.g. a duplicate
-	// series) cannot fail the whole scrape and blank out all other metrics.
-	http.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
-		ErrorHandling: promhttp.ContinueOnError,
-	}))
+	http.Handle("/metrics", metricsHandler(prometheus.DefaultGatherer))
 	http.ListenAndServe(address, nil) // nolint:errcheck,gosec
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// collidingCollector emits two samples with an identical label set, reproducing
+// what a secret with duplicated certificates used to do.
+type collidingCollector struct {
+	desc *prometheus.Desc
+}
+
+func (c *collidingCollector) Describe(ch chan<- *prometheus.Desc) { ch <- c.desc }
+func (c *collidingCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, 1, "colliding")
+	ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, 1, "colliding")
+}
+
+// healthyCollector emits an unrelated, well formed metric.
+type healthyCollector struct {
+	desc *prometheus.Desc
+}
+
+func (c *healthyCollector) Describe(ch chan<- *prometheus.Desc) { ch <- c.desc }
+func (c *healthyCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, 42, "healthy")
+}
+
+// TestMetricsHandler_DuplicateSeriesDoesNotFailScrape is the endpoint level
+// regression guard: even if some collector still manages to emit a duplicate
+// series, /metrics must answer 200 and keep serving the remaining metrics
+// instead of blanking out completely with HTTP 500.
+func TestMetricsHandler_DuplicateSeriesDoesNotFailScrape(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	desc := prometheus.NewDesc("cert_exporter_test_not_after", "test", []string{"name"}, nil)
+	if err := reg.Register(&collidingCollector{desc: desc}); err != nil {
+		t.Fatal(err)
+	}
+
+	healthyDesc := prometheus.NewDesc("cert_exporter_healthy_not_after", "test", []string{"name"}, nil)
+	if err := reg.Register(&healthyCollector{desc: healthyDesc}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	metricsHandler(reg).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected /metrics to return 200 despite a duplicate series, got %d", rec.Code)
+	}
+
+	body, err := io.ReadAll(rec.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(body), "cert_exporter_healthy_not_after") {
+		t.Fatal("expected unrelated metrics to still be served when another collector produces a duplicate series")
+	}
+}

--- a/tests/ats/cert_util.py
+++ b/tests/ats/cert_util.py
@@ -1,12 +1,15 @@
 # Source from https://stackoverflow.com/a/60804101
 # Licensed under CC BY-SA 4.0
 
+import secrets
+
 from OpenSSL import crypto
 
 
 def cert_gen(
     name="commonName",
     not_after=(10 * 365 * 24 * 60 * 60),
+    serial=None,
 ):
     # create a key pair
     k = crypto.PKey()
@@ -16,6 +19,16 @@ def cert_gen(
     cert = crypto.X509()
 
     cert.get_subject().CN = name
+
+    # Real certificates carry a unique serial number, and cert-exporter relies on
+    # it to tell certificates concatenated in one key apart. pyOpenSSL defaults
+    # to 0, so without this every generated certificate shared a serial and any
+    # test concatenating two of them would collide for reasons that have nothing
+    # to do with the exporter. Default to a unique serial so callers cannot hit
+    # that by omission; pass one explicitly when a test needs it to be stable.
+    if serial is None:
+        serial = secrets.randbits(64) + 1
+    cert.set_serial_number(serial)
 
     cert.gmtime_adj_notBefore(0)
     cert.gmtime_adj_notAfter(not_after)

--- a/tests/ats/test_cert_exporter.py
+++ b/tests/ats/test_cert_exporter.py
@@ -347,16 +347,24 @@ def test_secret_metrics_with_concatenated_certificates(
     leaf_expires_in_secs = 3600
     ca_expires_in_secs = 7200
 
+    # Pinned so the test can assert on the serialnumber label without depending
+    # on how long key generation took.
+    leaf_serial = 1001
+    ca_serial = 1002
+    unrelated_serial = 1003
+
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Distinct serial numbers, as real certificates have.
         (leaf, leaf_key) = cert_gen(
-            name=chain_name, not_after=leaf_expires_in_secs, serial=1001
+            name=chain_name, not_after=leaf_expires_in_secs, serial=leaf_serial
         )
         (ca, _) = cert_gen(
-            name=f"{chain_name}-ca", not_after=ca_expires_in_secs, serial=1002
+            name=f"{chain_name}-ca", not_after=ca_expires_in_secs, serial=ca_serial
         )
         (unrelated, unrelated_key) = cert_gen(
-            name=unrelated_name, not_after=leaf_expires_in_secs, serial=1003
+            name=unrelated_name,
+            not_after=leaf_expires_in_secs,
+            serial=unrelated_serial,
         )
 
         chain_path = f"{tmpdirname}/{chain_name}.crt"
@@ -412,21 +420,29 @@ def test_secret_metrics_with_concatenated_certificates(
             f"{chain_metrics}"
         )
 
-        expected_expiries = [
-            int((datetime.now() + timedelta(seconds=s)).strftime("%s"))
-            for s in (leaf_expires_in_secs, ca_expires_in_secs)
-        ]
-        for expected_expiry in expected_expiries:
-            assert (
-                len([m for m in chain_metrics if check_expiry(expected_expiry)(m)]) == 1
-            )
+        # Both certificates are there, told apart by the serialnumber label that
+        # v2.11.1 added. Asserting on the serials instead of on expiry
+        # timestamps keeps this independent of how long key generation and
+        # secret creation took. The exporter formats the serial as lowercase hex.
+        expected_serials = {f"{leaf_serial:x}", f"{ca_serial:x}"}
+        got_serials = {m.split('serialnumber="')[1].split('"')[0] for m in chain_metrics}
+        assert got_serials == expected_serials, (
+            f"expected serials {sorted(expected_serials)}, got {sorted(got_serials)}: "
+            f"{chain_metrics}"
+        )
 
         # The unrelated secret must still be exported. This is what silently
         # disappeared when the colliding samples failed the whole scrape.
-        assert_metric(
-            deploy_metrics,
+        unrelated_prefix = (
             f'{metric_name}{{certificatename="",name="{unrelated_name}",'
-            f'namespace="default",secretkey="tls.crt"',
+            f'namespace="default",secretkey="tls.crt"'
+        )
+        unrelated_metrics = [
+            m for m in deploy_metrics if m.startswith(unrelated_prefix)
+        ]
+        assert len(unrelated_metrics) == 1, (
+            "expected the unrelated secret to still be exported, got "
+            f"{unrelated_metrics}"
         )
     finally:
         # cleanup

--- a/tests/ats/test_cert_exporter.py
+++ b/tests/ats/test_cert_exporter.py
@@ -321,6 +321,122 @@ def test_secret_metrics(
 
 
 @pytest.mark.functional
+# Not marked as upgrade: the previous released chart does not contain the fix
+# this test asserts on, so it can only run against the chart under test.
+def test_secret_metrics_with_concatenated_certificates(
+    kube_cluster: Cluster,
+    certexporter_deployment: List[pykube.Deployment],
+):
+    """Regression test for https://github.com/giantswarm/roadmap/issues/4323.
+
+    A secret key holding several concatenated certificates (as produced by e.g.
+    Kyverno webhook cert rotation) used to emit samples with identical label
+    sets. Prometheus rejected the scrape with HTTP 500, so the whole /metrics
+    endpoint went blank, not just that secret's metric. Each certificate in the
+    chain must be reported, and unrelated secrets must keep being served even
+    though the chain repeats a certificate.
+    """
+    # patch services to be type: NodePort
+    prepare_services(kube_cluster)
+
+    metric_name = "cert_exporter_secret_not_after"
+
+    chain_name = "concatenated-cert"
+    unrelated_name = "unrelated-cert"
+
+    leaf_expires_in_secs = 3600
+    ca_expires_in_secs = 7200
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Distinct serial numbers, as real certificates have.
+        (leaf, leaf_key) = cert_gen(
+            name=chain_name, not_after=leaf_expires_in_secs, serial=1001
+        )
+        (ca, _) = cert_gen(
+            name=f"{chain_name}-ca", not_after=ca_expires_in_secs, serial=1002
+        )
+        (unrelated, unrelated_key) = cert_gen(
+            name=unrelated_name, not_after=leaf_expires_in_secs, serial=1003
+        )
+
+        chain_path = f"{tmpdirname}/{chain_name}.crt"
+        chain_key_path = f"{tmpdirname}/{chain_name}.key"
+        unrelated_path = f"{tmpdirname}/{unrelated_name}.crt"
+        unrelated_key_path = f"{tmpdirname}/{unrelated_name}.key"
+
+        # Leaf, its CA, and the CA a second time. The repeated certificate is
+        # what used to produce two samples with identical labels.
+        with open(chain_path, "wt") as f:
+            f.write(leaf + ca + ca)
+
+        with open(chain_key_path, "wt") as f:
+            f.write(leaf_key)
+
+        with open(unrelated_path, "wt") as f:
+            f.write(unrelated)
+
+        with open(unrelated_key_path, "wt") as f:
+            f.write(unrelated_key)
+
+        kube_cluster.kubectl(
+            f"create secret tls {chain_name}",
+            output_format="",
+            cert=chain_path,
+            key=chain_key_path,
+        )
+        kube_cluster.kubectl(
+            f"create secret tls {unrelated_name}",
+            output_format="",
+            cert=unrelated_path,
+            key=unrelated_key_path,
+        )
+
+    # let the dust settle
+    time.sleep(5)
+
+    try:
+        # retrieve_metrics asserts the endpoint answers 200 and returns samples,
+        # which is the core of the regression: it used to be 500 and empty.
+        deploy_metrics = retrieve_metrics(deployment_port)
+
+        chain_prefix = (
+            f'{metric_name}{{certificatename="",name="{chain_name}",'
+            f'namespace="default",secretkey="tls.crt"'
+        )
+        chain_metrics = [m for m in deploy_metrics if m.startswith(chain_prefix)]
+
+        # Leaf and CA, each reported exactly once. The repeated CA must not add
+        # a second, colliding sample.
+        assert len(chain_metrics) == 2, (
+            f"expected 2 samples for the concatenated chain, got {len(chain_metrics)}: "
+            f"{chain_metrics}"
+        )
+
+        expected_expiries = [
+            int((datetime.now() + timedelta(seconds=s)).strftime("%s"))
+            for s in (leaf_expires_in_secs, ca_expires_in_secs)
+        ]
+        for expected_expiry in expected_expiries:
+            assert (
+                len([m for m in chain_metrics if check_expiry(expected_expiry)(m)]) == 1
+            )
+
+        # The unrelated secret must still be exported. This is what silently
+        # disappeared when the colliding samples failed the whole scrape.
+        assert_metric(
+            deploy_metrics,
+            f'{metric_name}{{certificatename="",name="{unrelated_name}",'
+            f'namespace="default",secretkey="tls.crt"',
+        )
+    finally:
+        # cleanup
+        kube_cluster.kubectl(
+            f"delete secret {chain_name} {unrelated_name}",
+            output_format="",
+        )
+
+
+@pytest.mark.functional
 # @pytest.mark.upgrade
 def test_certificate_cr_metrics(
     request,


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4323

Regression tests for the `/metrics` failure introduced in v2.10.1, where certificates concatenated in a single secret key produced samples with identical label sets and Prometheus rejected the whole scrape with HTTP 500 — so every metric disappeared, not just the affected secret's.

The v2.11.1 fix already works; this pins both halves of it. Verified by reverting each half in turn:

- Removing the `serialnumber` label fails `TestGather_MultipleCertsInSameKey`, `TestGather_LeafPlusCA` and `TestGather_MultipleCertsInSameFile`.
- Switching the handler back from `ContinueOnError` fails `TestMetricsHandler_DuplicateSeriesDoesNotFailScrape` with `got 500`, which is the original customer symptom.

No behaviour change. `metricsHandler` and `newCertDesc` are extracted so the tests exercise the real handler configuration and the real label set — the test helpers previously hand-copied the label list, so dropping `serialnumber` in production would not have failed anything.

ATS: adds an end to end test for a secret whose `tls.crt` holds a concatenated chain (leaf + CA + repeated CA), asserting the endpoint stays 200, both certificates are reported, and an unrelated secret is still served. `cert_gen` never called `set_serial_number`, so every generated certificate had serial `0` and any e2e test concatenating certs would have collided as a harness artifact; it now defaults to a unique serial.